### PR TITLE
Updated Three Lib URLs

### DIFF
--- a/auto-generated-widget.html
+++ b/auto-generated-widget.html
@@ -91,10 +91,10 @@
     //<![CDATA[
 requirejs.config({
     paths: {
-        Three: 'http://threejs.org/build/three.min',
-        ThreeTextGeometry: 'http://chilipeppr.com/js/three/TextGeometry',
-        ThreeFontUtils: 'http://chilipeppr.com/js/three/FontUtils',
-        ThreeHelvetiker: 'http://chilipeppr.com/js/three/threehelvetiker'
+       Three: '//i2dcui.appspot.com/geturl?url=http://threejs.org/build/three.js',
+        ThreeTextGeometry: '//i2dcui.appspot.com/js/three/TextGeometry',
+        ThreeFontUtils: '//i2dcui.appspot.com/js/three/FontUtils',
+        ThreeHelvetiker: '//i2dcui.appspot.com/js/three/threehelvetiker'
     },
     shim: {
         ThreeTextGeometry: ['Three'],


### PR DESCRIPTION
Fixes an error that may not always appear in which the autolevel function will not work due to conflicting Three.js libraries. The solution is to update them in this widget to be contiguous with the workspace URLs.
